### PR TITLE
#39: implement explicit custody

### DIFF
--- a/src/anchovy/core.py
+++ b/src/anchovy/core.py
@@ -128,7 +128,17 @@ class Context:
         further_processing: list[Path] = []
         for step, path, output_paths in track_progress(flattened, 'Processing...'):
             print(f'{path} ⇒ {", ".join(str(p) for p in output_paths)}')
-            step(path, output_paths)
+            explicit_chain = step(path, output_paths)
+            if explicit_chain:
+                source_paths, output_paths = explicit_chain
+                print(
+                    '• explicit custody: {\n\t',
+                    ',\n\t'.join(str(p) for p in source_paths),
+                    '\n} ⇒ {\n\t',
+                    ',\n\t'.join(str(p) for p in output_paths),
+                    '\n}',
+                    sep=''
+                )
             further_processing.extend(
                 p for p in output_paths
                 if p.is_relative_to(self['working_dir'])
@@ -259,7 +269,11 @@ class Step(abc.ABC):
         self.context = context
 
     @abc.abstractmethod
-    def __call__(self, path: Path, output_paths: list[Path]):
+    def __call__(
+        self,
+        path: Path,
+        output_paths: list[Path]
+    ) -> None | tuple[list[Path], list[Path]]:
         ...
 
 

--- a/src/anchovy/jinja.py
+++ b/src/anchovy/jinja.py
@@ -67,6 +67,8 @@ class JinjaRenderStep(Step):
         for path in output_paths[1:]:
             shutil.copy(output_paths[0], path)
 
+        return template.filename
+
 
 class JinjaMarkdownStep(JinjaRenderStep):
     """
@@ -155,11 +157,13 @@ class JinjaMarkdownStep(JinjaRenderStep):
         meta, content = self.extract_metadata(path.read_text(self.encoding))
         meta |= {'rendered_markdown': self.md_processor(content.strip()).strip()}
 
-        self.render_template(
+        template_path = self.render_template(
             meta.get('template', self.default_template),
             meta,
             output_paths
         )
+        if template_path:
+            return [path, Path(template_path)], output_paths
 
     def extract_metadata(self, text: str):
         """

--- a/src/anchovy/minify.py
+++ b/src/anchovy/minify.py
@@ -13,16 +13,21 @@ class ResourcePackerStep(Step):
 
     def __call__(self, path: Path, output_paths: list[Path]):
         parent_dir = self.context[self.source_dir]
-        data = '\n\n'.join(
-            (parent_dir / f).read_text(self.encoding)
-            for filename in path.open() if (f := filename.strip()) and not f.startswith('#')
-        )
+        input_paths = [
+            (parent_dir / f)
+            for filename in path.open()
+            if (f := filename.strip()) and not f.startswith('#')
+        ]
+        data = '\n\n'.join(f.read_text(self.encoding) for f in input_paths)
 
         for o_path in output_paths:
             o_path.parent.mkdir(parents=True, exist_ok=True)
         output_paths[0].write_text(data, self.encoding)
         for o_path in output_paths[1:]:
             shutil.copy(output_paths[0], o_path)
+
+        input_paths.insert(0, path)
+        return input_paths, output_paths
 
 
 class CSSMinifierStep(Step):


### PR DESCRIPTION
Allows Steps to return explicit chain-of-custody data at runtime.